### PR TITLE
New SheetsGroup object created for easy exporting of PDFs

### DIFF
--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -2965,6 +2965,15 @@ class SheetsGroup(Collection):
         self._group_names.add(sh.name.lower())
         return self(sh.name)
 
+    def toggle_visibility(self, visible=None):
+        toggle = {-1:0, 2:-1, 0:-1}
+        if visible is None:
+            for sh in self:
+                sh.visible = toggle[sh.visible]
+        else:
+            for sh in self:
+                sh.visible = visible
+
     def export(self, type='PDF', filename=None, quality=0, include_doc_properties=True, ignore_print_areas=False, first=None, last=None, open_after_publish=True):
         """
         Exports the sheet group workbook to the selected file type (PDF or XPS) including only the sheets in the sheet group.

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -2930,6 +2930,54 @@ class SheetsGroup(Collection):
         self._group_names.add(sh.name.lower())
         return self(sh.name)
 
+    def export(self, type='PDF', filename=None, quality=0, include_doc_properties=True, ignore_print_areas=False, first=None, last=None, open_after_publish=True):
+        """
+        Exports the sheet group workbook to the selected file type (PDF or XPS) including only the sheets in the sheet group.
+
+        This is accomplished by hiding the sheets that are not in the sheet group before exporting the containing workbook.
+
+        Parameters
+        ----------
+        type : str, default PDF
+            Export file type. Options are PDF or XPS.
+        filename : str, default None
+            Name of the exported file. If None, will default to the Excel workbook name.
+        quality : int, default 0
+            Choices are 0: standard quality and 1: minimum quality.
+        include_doc_properties : bool, default True
+            Set to True to indicate that document properties should be included or set to False to indicate that they are omitted.
+        ignore_print_areas : bool, default False
+            If set to True, ignores any print areas set when publishing. If set to False , will use the print areas set when publishing.
+        first : int, default None
+            Specifies the first page number to be printed. If None, will default to page 1.
+        last : int, default None
+            Specifies the last page number to be printed. If None, will default to the last page.
+        open_after_publish : bool, default True
+            If set to True displays file in viewer after it is published. If set to False the file is published but not displayed.
+
+        Returns
+        -------
+
+        """
+        try:
+            wb = self(1).book
+        except IndexError:
+            raise TypeError("Cannot export an empty sheet group.")
+        visible = []
+        for sh in wb.sheets:
+            visible.append(sh.visible)
+            sh.visible = -1
+        for sh in wb.sheets:
+            if sh.name.lower() not in self._group_names:
+                sh.visible = 0
+        wb.export(type, filename, quality, include_doc_properties, ignore_print_areas, first, last, open_after_publish)
+        for sh,v in zip(wb.sheets, visible):
+            if v == -1:
+                sh.visible = v
+        for sh,v in zip(wb.sheets, visible):
+            if v != -1:
+                sh.visible = v
+
 
 class ActiveAppBooks(Books):
 

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -742,6 +742,41 @@ class Book(object):
         else:
             return "<Book [{0}]>".format(self.name)
 
+    def export(self, type='PDF', filename=None, quality=0, include_doc_properties=True, ignore_print_areas=False, first=None, last=None, open_after_publish=True):
+        """
+        Exports the workbook to the selected file type (PDF or XPS).
+
+        Parameters
+        ----------
+        type : str, default PDF
+            Export file type. Options are PDF or XPS.
+        filename : str, default None
+            Name of the exported file. If None, will default to the Excel workbook name.
+        quality : int, default 0
+            Choices are 0: standard quality and 1: minimum quality.
+        include_doc_properties : bool, default True
+            Set to True to indicate that document properties should be included or set to False to indicate that they are omitted.
+        ignore_print_areas : bool, default False
+            If set to True, ignores any print areas set when publishing. If set to False , will use the print areas set when publishing.
+        first : int, default None
+            Specifies the first page number to be printed. If None, will default to page 1.
+        last : int, default None
+            Specifies the last page number to be printed. If None, will default to the last page.
+        open_after_publish : bool, default True
+            If set to True displays file in viewer after it is published. If set to False the file is published but not displayed.
+
+        Returns
+        -------
+
+        """
+        try:
+            type_v = {"pdf":0, ".pdf":0, "xps":1, ".xps":1}[type.lower()]
+        except KeyError:
+            raise ValueError("Invalid type provided, '%s' - type must be PDF or XPS" % key)
+        kwargs_ = dict(Type=type_v, Filename=str(filename) if filename is not None else None, Quality=quality, IncludeDocProperties=include_doc_properties, IgnorePrintAreas=ignore_print_areas, From=first, To=last, OpenAfterPublish=open_after_publish)
+        kwargs = dict((k,v) for k,v in kwargs_.items() if v is not None)
+        self.api.ExportAsFixedFormat(**kwargs)
+
 
 class Sheet(object):
     """

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -783,6 +783,27 @@ class Sheet(object):
         return hash((self.book, self.name))
 
     @property
+    def visible(self):
+        """
+        Gets or sets the visibility of a worksheet. Options are:
+        
+        -1: visible
+        0: hidden
+        2: very hidden
+
+        .. versionadded:: ______
+        """
+        return self.api.Visible
+
+    @visible.setter
+    def visible(self, value):
+        if value not in (-1, 0, 2):
+            raise ValueError("Invalid value for visible property provided.")
+        if value!=-1 and not any(sh.visible==-1 for sh in self.book.sheets if sh.name!=self.name):
+            raise Exception("Cannot hide last visible sheet")
+        self.api.Visible = value
+
+    @property
     def name(self):
         """Gets or sets the name of the Sheet."""
         return self.impl.name

--- a/xlwings/main.py
+++ b/xlwings/main.py
@@ -648,6 +648,15 @@ class Book(object):
         """
         return Sheets(impl=self.impl.sheets)
 
+    def sheets_group(self, *name_or_index):
+        """
+        Returns a sheets collection that represents a subset the sheets in the book.
+
+        .. versionadded:: ____
+        """
+        
+        return SheetsGroup(self.sheets.impl, *name_or_index)
+
     @property
     def app(self):
         """

--- a/xlwings/tests/common.py
+++ b/xlwings/tests/common.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import os
 import inspect
 import unittest
+import shutil
 
 import xlwings as xw
 
@@ -18,6 +19,11 @@ class TestBase(unittest.TestCase):
     def setUpClass(cls):
         cls.app1 = xw.App(visible=False, spec=SPEC)
         cls.app2 = xw.App(visible=False, spec=SPEC)
+        cls.tmp=os.path.realpath(os.path.join(this_dir,'_tmp'))
+        try:
+            os.makedirs(self.tmp)
+        except OSError:
+            pass
 
     def setUp(self):
         self.wb1 = self.app1.books.add()
@@ -36,3 +42,7 @@ class TestBase(unittest.TestCase):
     def tearDownClass(cls):
         cls.app1.kill()
         cls.app2.kill()
+        try:
+            shutil.rmtree(cls.tmp)
+        except OSError:
+            pass

--- a/xlwings/tests/test_book.py
+++ b/xlwings/tests/test_book.py
@@ -216,5 +216,10 @@ class TestBook(TestBase):
         self.wb1.sheets.add()
         self.assertEqual(len(self.wb1.sheets), 4)
 
+    def test_export(self):
+        filename='test.pdf'
+        self.wb1.sheets(1)['a1'].value = 1 # can't export empty sheet
+        self.wb1.export(filename=os.path.join(self.tmp,filename), open_after_publish=False)
+
 if __name__ == '__main__':
     unittest.main()

--- a/xlwings/tests/test_book.py
+++ b/xlwings/tests/test_book.py
@@ -216,6 +216,10 @@ class TestBook(TestBase):
         self.wb1.sheets.add()
         self.assertEqual(len(self.wb1.sheets), 4)
 
+    def test_sheets_group(self):
+        grp=self.wb1.sheets_group('Sheet1')
+        self.assertEqual(len(grp, 1))
+
     def test_export(self):
         filename='test.pdf'
         self.wb1.sheets(1)['a1'].value = 1 # can't export empty sheet

--- a/xlwings/tests/test_sheet.py
+++ b/xlwings/tests/test_sheet.py
@@ -136,6 +136,18 @@ class TestSheet(TestBase):
         self.wb1.sheets['Sheet1'].delete()
         self.assertFalse('Sheet1' in [i.name for i in self.wb1.sheets])
 
+    def test_visible_get(self):
+        self.assertTrue(all(i.visible==-1 for i in self.wb1.sheets))
+
+    def test_visible_set(self):
+        self.wb1.sheets(1).visible = 0
+        self.assertTrue(self.wb1.sheets(1).visible==0)
+
+    def test_visible_hide_last(self):
+        # the last visible sheet cannot be hidden
+        with self.assertRaises(Exception):
+            for s in self.wb1.sheets:
+                s.visible = 0
 
 if __name__ == '__main__':
     unittest.main()

--- a/xlwings/tests/test_sheets_group.py
+++ b/xlwings/tests/test_sheets_group.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import pytest
+
+import xlwings as xw
+
+def make_app():
+    return xw.App(visible=False)
+
+@pytest.fixture(scope="module")
+def app1():
+    app = make_app()
+    yield app
+    app.kill()
+
+@pytest.fixture(scope="module")
+def app2():
+    app = make_app()
+    yield app
+    app.kill()
+
+def make_wb(app):
+    wb = app.books.add()
+    if len(wb.sheets) == 1:
+        wb.sheets.add(after=1)
+        wb.sheets.add(after=2)
+        wb.sheets[0].select()
+    return wb
+
+@pytest.fixture
+def wb1(app1):
+    yield make_wb(app1)
+    app1.books[-1].close()
+
+@pytest.fixture
+def wb2(app2):
+    yield make_wb(app2)
+    app2.books[-1].close()
+
+def make_grp(wb, *sheets):
+    grp = wb.sheets_group(*sheets)
+    return grp
+
+@pytest.fixture
+def grp1(wb1):
+    yield make_grp(wb1, 'sheet1', 'sheet2')
+
+@pytest.fixture
+def grp2(wb2):
+    yield make_grp(wb2, 'sheet2', 'sheet3')
+
+def test_active(grp1):
+    assert grp1.active.name == grp1[0].name
+
+def test_active_not_in_group(grp2):
+    with pytest.raises(Exception):
+        grp2.active
+
+def test_index(grp1):
+    assert grp1[0].name == grp1(1).name
+
+def test_len(grp1):
+    assert len(grp1) == 2
+
+def test_del_sheet(grp1):
+    name = grp1[0].name
+    del grp1[0]
+    assert len(grp1) == 1
+    assert grp1[0].name != name
+
+def test_iter(grp1):
+    for ix, sht in enumerate(grp1):
+        assert grp1[ix].name == sht.name
+
+def test_add(grp1):
+    grp1.add()
+    assert len(grp1) == 3
+
+def test_add_before(grp1):
+    new_sheet = grp1.add(before='Sheet1')
+    assert grp1[0].name == new_sheet.name
+
+def test_add_after(grp1):
+    grp1.add(after=len(grp1))
+    assert grp1[(len(grp1) - 1)].name == grp1.active.name
+
+    grp1.add(after=1)
+    assert grp1[1].name == grp1.active.name
+
+def test_add_default(grp1):
+    current_index = grp1.active.index
+    grp1.add()
+    assert grp1.active.index == current_index
+
+def test_add_named(grp1):
+    grp1.add('test', before=1)
+    assert grp1[0].name == 'test'
+
+def test_add_name_already_taken(grp1):
+    # does not raise exception because just adds existing sheet to group
+    grp1.add('Sheet3')
+    assert grp1[2].name.lower() == 'sheet3'
+
+

--- a/xlwings/tests/test_sheets_group.py
+++ b/xlwings/tests/test_sheets_group.py
@@ -1,8 +1,24 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import pytest
+import inspect
+from os import path, makedirs
+import shutil
 
 import xlwings as xw
+
+@pytest.fixture
+def tmpdir(scope="module"):
+    tmp=path.realpath(path.join(path.dirname(inspect.getfile(inspect.currentframe())),'_tmp'))
+    try:
+        makedirs(tmp)
+    except OSError:
+        pass
+    yield tmp
+    try:
+        shutil.rmtree(tmp)
+    except OSError:
+        pass
 
 def make_app():
     return xw.App(visible=False)
@@ -100,5 +116,11 @@ def test_add_name_already_taken(grp1):
     # does not raise exception because just adds existing sheet to group
     grp1.add('Sheet3')
     assert grp1[2].name.lower() == 'sheet3'
+
+def test_export(grp1,tmpdir):
+    filename='test.pdf'
+    grp1.active['A1'].value='test'
+    grp1.export(filename=path.join(tmpdir,filename), open_after_publish=False)
+
 
 


### PR DESCRIPTION
The native Excel application can only export ALL the visible sheets of a workbook to a PDF file. If one wants to export a subset of the sheets, one has to go through the exercise of hiding all the ones that one doesn't want exported, exporting the workbook, and then unhiding them. This is annoying.

The SheetsGroup object is an object that represents a subset of sheets in a workbook. The impl member for the object is the FULL Book.impl.sheets object - including ALL the sheets... this might be a bit confusing but I can't think of a better way to do it.

The sheets in a SheetsGroup are defined by the names of the sheets (stored in a set since order isn't relevant). Unfortunately this means that if a sheets name is changed, the sheet will not be a part of an already instantiated sheet group object anymore (unless manually added). I briefly explored the idea of using sheet codenames rather than names, but the same problem would persist (the sheets group instance isn't updated if a sheet codename is changed) so this seemed pointless.

One potential enhancement might be for each Book to be aware of its sheets group objects so that they can be updated when a sheet name is changed. However this seems unnecessary at the moment.